### PR TITLE
Wrapping bug

### DIFF
--- a/resources/css/index.css
+++ b/resources/css/index.css
@@ -500,7 +500,7 @@ li {
     }
 
     .section-3-left-container {
-        width: 32vw;
+        width: 31.25vw;
     }
 
     .section-3-top-left {


### PR DESCRIPTION
Wrapping of section-3-right for smaller screen sizes has been patched. Solution was to decrease the section-3-left-containers width to more accurately fit the two images populating the container.